### PR TITLE
Empty CLI table alignment fix

### DIFF
--- a/model/Constants.py
+++ b/model/Constants.py
@@ -1,3 +1,3 @@
 # Version control
-CURRENT_VERSION = '0.2.0'
+CURRENT_VERSION = '0.2.1'
 NPOINT_IO_ID = '90ac552c3f0a9edd27c1'

--- a/util/cli/CliTable.py
+++ b/util/cli/CliTable.py
@@ -72,9 +72,9 @@ class CliTable:
 
     def _print_empty(self):
         number_of_chars = self.get_ui_length() - 4
-        print('# ')
-        print(f'The view is currently empty'.rjust(number_of_chars))
-        print(' #')
+        print('# ', end='')
+        print(f'The view is currently empty'.center(number_of_chars), end='')
+        print(' #',)
         self._seperator_line()
 
     def _print_header(self):


### PR DESCRIPTION
Fixed CliTable on Empty view, as the printstatements used newline when they shoudn't